### PR TITLE
code-review

### DIFF
--- a/workshop-1/jugistanbul-slugifier/src/jug/istanbul/slugifier/Slugifier.java
+++ b/workshop-1/jugistanbul-slugifier/src/jug/istanbul/slugifier/Slugifier.java
@@ -6,48 +6,39 @@ import java.text.Normalizer;
 
 public class Slugifier
 {
-    public static String run ( String text )
+    private Slugifier() {
+    }
+    
+    public static String slugify ( String text ) throws UnsupportedEncodingException
     {
-        if ( text == null || text.length () == 0 )
+        if ( text == null || text.isEmpty() )
         {
             return "";
         }
 
-        String toReturn = "";
-        try
-        {
-            String normalizedText = normalize ( text );
-            normalizedText = normalizedText.replaceAll ( "[^\\w\\s\\-]", "" );
-            normalizedText = normalizedText.replaceAll ( " ", "-" );
-            normalizedText = normalizedText.toLowerCase ();
-            toReturn = URLEncoder.encode ( normalizedText, "UTF-8" );
-        }
-        catch ( UnsupportedEncodingException e )
-        {
-            // TODO: Log the exception
-            e.printStackTrace ();
-        }
-
-        return toReturn;
+        String normalizedText = normalize ( text )
+            .replaceAll ( "[^\\w\\s\\-]", "" )
+            .replaceAll ( " ", "-" )
+            .toLowerCase ();
+        return URLEncoder.encode ( normalizedText, "UTF-8" );
     }
 
-    public static String convertCharactersFromTurkishToEnglish ( String text )
+    private static String convertCharactersFromTurkishToEnglish ( String text )
     {
-        text = text.replaceAll ( "ü", "u" );
-        text = text.replaceAll ( "ı", "i" );
-        text = text.replaceAll ( "ö", "o" );
-        text = text.replaceAll ( "ü", "u" );
-        text = text.replaceAll ( "ş", "s" );
-        text = text.replaceAll ( "ğ", "g" );
-        text = text.replaceAll ( "ç", "c" );
-        text = text.replaceAll ( "Ü", "U" );
-        text = text.replaceAll ( "İ", "I" );
-        text = text.replaceAll ( "Ö", "O" );
-        text = text.replaceAll ( "Ü", "U" );
-        text = text.replaceAll ( "Ş", "S" );
-        text = text.replaceAll ( "Ğ", "G" );
-        text = text.replaceAll ( "Ç", "C" );
-        return text;
+        return text.replaceAll ( "ü", "u" )
+            .replaceAll ( "ı", "i" )
+            .replaceAll ( "ö", "o" )
+            .replaceAll ( "ü", "u" )
+            .replaceAll ( "ş", "s" )
+            .replaceAll ( "ğ", "g" )
+            .replaceAll ( "ç", "c" )
+            .replaceAll ( "Ü", "U" )
+            .replaceAll ( "İ", "I" )
+            .replaceAll ( "Ö", "O" )
+            .replaceAll ( "Ü", "U" )
+            .replaceAll ( "Ş", "S" )
+            .replaceAll ( "Ğ", "G" )
+            .replaceAll ( "Ç", "C" );
     }
 
     private static String normalize ( String input )


### PR DESCRIPTION
yordamın adı `run` yerine `slugify` olmalı, `run`, `Runnable`'dan türediği izlenimini yaratıyor.

sınıfın yordamlarının tamamı static olduğu için `private` ctor eklendi - yeni bir instance yaratılmasını engellemek için

`String#replaceAll` satırlarındaki string atamaları gereksiz.

`convertCharactersFromTurkishToEnglish` yordamında gönderilen orijinal metni değiştirmek yerine başka bir metin referansı dönmek daha anlamlı olur -metnin orijinali sonraki satırlarda kullanılmak istenebilir.

bunun dışında, kütüphane olarak kullanılacak bir kodun karşılaştığı hataları (sarmalayarak ya da sarmalamadan) fırlatması daha doğru olur

`convertCharactersFromTurkishToEnglish` yordamı `private` olabilirdi, yapıldı

`String#length` control yerine `String#isEmpty` önerilir

*not: GitHub üzerinden, derlemeden açıyorum - typo varsa affola*